### PR TITLE
Add test coverage

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,26 +4,24 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
-- name: debian-6.0.10
-  driver_config:
-    box: opscode-debian-6.0.10
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10_chef-provisionerless.box
-- name: debian-7.1.0
-  driver_config:
-    box: opscode-debian-7.1.0
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_debian-7.1.0_provisionerless.box
-- name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-- name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
+  - name: fedora-21
+    run_list:
+    - recipe[yum]
+  - name: ubuntu-12.04
+    run_list:
+    - recipe[apt]
+  - name: ubuntu-14.04
+    run_list:
+    - recipe[apt]
+  - name: debian-7.1.0
+    run_list:
+    - recipe[apt]
 
 suites:
 - name: default
-  run_list: ['recipe[apt]','recipe[postfix]','recipe[rkhunter]']
+  run_list:
+    - recipe[postfix]
+    - recipe[rkhunter]
   attributes: {
     postfix: {
       main: {

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,6 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook "apt"
-cookbook "postfix"
+cookbook 'apt'
+cookbook 'postfix'

--- a/Berksfile
+++ b/Berksfile
@@ -4,3 +4,4 @@ metadata
 
 cookbook 'apt'
 cookbook 'postfix'
+cookbook 'yum'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.1'
 depends 'apt'
 depends 'postfix'
+depends 'yum'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,25 @@
+# encoding: UTF-8
+# License:: Apache License, Version 2.0
+#
+
+require_relative 'spec_helper'
+
+describe package('rkhunter') do
+  it { should be_installed   }
+end
+
+describe file('/etc/default/rkhunter') do
+  it { should be_file }
+  it { should be_mode '644' }
+  it { should be_owned_by 'root' }
+  its(:content) { should match(/^CRON_DAILY_RUN=true/) }
+  its(:content) { should match(/^CRON_DB_UPDATE=true/) }
+  its(:content) { should match(/^DB_UPDATE_EMAIL=true/) }
+  its(:content) { should match(/^REPORT_EMAIL=you@example.com/) }
+end
+
+describe file('/etc/rkhunter.conf') do
+  it { should be_file }
+  it { should be_mode '644' }
+  it { should be_owned_by 'root' }
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+
+# Set backend type
+set :backend, :exec

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -1,0 +1,25 @@
+require_relative 'spec_helper'
+
+describe 'rkhunter::default' do
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
+  it "installs rkhunter" do
+    expect(chef_run).to upgrade_package('rkhunter')
+  end
+  
+  it "write defaults file" do
+    expect(chef_run).to create_template('/etc/default/rkhunter').with(
+      user: 'root',
+      group: 0,
+      mode: 00644
+    )
+  end
+
+  it "write rkhunter config file" do
+    expect(chef_run).to create_cookbook_file('/etc/rkhunter.conf').with(
+      user: 'root',
+      group: 0,
+      mode: 00644
+    )
+  end
+end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
This adds minimal unit and integration tests to confirm the `rkhunter` package gets installed and the template and cookbook file get written

Just run `$ rspec test/unit/spec` or `kitchen test` and the respective tests will be run.

Updated and simplified `.kitchen.yml` to include Ubuntu 14, drop Ubuntu 10, drop Debian 6 and add Fedora 21.