### PR TITLE
Fix travis, add rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ rvm:
   - 1.9.3
   bundler_args: --without integration development
   script:
-    - bundle exec foodcritic -f any .
-    - bundle exec rubocop
+    - bundle exec rake ci

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,14 @@ gem 'berkshelf'
 #   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
 # end
 
-gem 'test-kitchen'
-gem 'kitchen-vagrant'
-gem 'foodcritic'
-gem 'rubocop'
-gem 'rspec'
+group :style do
+  gem 'foodcritic'
+  gem 'rubocop'
+end
+
+group :test do
+  gem 'chefspec'
+  gem 'rspec'
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,50 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+namespace :style do
+  begin
+    require 'rubocop/rake_task'
+    desc 'Run Ruby style checks'
+    RuboCop::RakeTask.new(:ruby)
+  rescue LoadError
+    puts '>>>>> Rubocop gem not loaded, omitting tasks' unless ENV['CI']
+  end
+
+  begin
+    require 'foodcritic'
+
+    desc 'Run Chef style checks'
+    FoodCritic::Rake::LintTask.new(:chef) do |t|
+      t.options = {
+        :fail_tags => ['any']
+      }
+    end
+  rescue LoadError
+    puts '>>>>> foodcritic gem not loaded, omitting tasks' unless ENV['CI']
+  end
+end
+
+desc 'Run all style checks'
+task :style => %w(style:chef style:ruby)
+
+task :unit do
+  sh "bundle exec 'rspec ./test/unit/spec/ --color --format documentation'"
+end
+
+desc 'Run Test Kitchen integration tests'
+task :integration do
+  begin
+    require 'kitchen/rake_tasks'
+
+    desc 'Run kitchen integration tests'
+    Kitchen::RakeTasks.new
+  rescue LoadError
+    puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+  end
+end
+
+desc 'Run tests on Travis'
+task :ci => %w(style)
+
+task :default => %w(style unit integration)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-#/etc/default/rkhunter values
+# /etc/default/rkhunter values
 default['rkhunter']['cron_daily_run']	= true
 default['rkhunter']['cron_db_update'] = true
 default['rkhunter']['db_update_email'] = true
@@ -7,7 +7,7 @@ default['rkhunter']['apt_autogen'] = false
 default['rkhunter']['nice']	= '0'
 default['rkhunter']['run_check_on_battery']	= false
 
-#/etc/rkhunter.conf values
+# /etc/rkhunter.conf values
 default['rkhunter']['allow_ssh_root_user'] = 'no'
 default['rkhunter']['scriptwhitelist'] = []
 default['rkhunter']['allowhiddendir'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name 'rkhunter'
 maintainer 'gregpalmier'
 maintainer_email 'gregpalmier@gmail.com'
-license 'All rights reserved'
+license 'Apache 2.0'
 description 'Installs/Configures rkhunter'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.5'

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -3,23 +3,23 @@ require_relative 'spec_helper'
 describe 'rkhunter::default' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it "installs rkhunter" do
+  it 'installs rkhunter' do
     expect(chef_run).to upgrade_package('rkhunter')
   end
-  
-  it "write defaults file" do
+
+  it 'write defaults file' do
     expect(chef_run).to create_template('/etc/default/rkhunter').with(
-      user: 'root',
-      group: 0,
-      mode: 00644
+      :user => 'root',
+      :group => 0,
+      :mode => 00644
     )
   end
 
-  it "write rkhunter config file" do
-    expect(chef_run).to create_cookbook_file('/etc/rkhunter.conf').with(
-      user: 'root',
-      group: 0,
-      mode: 00644
+  it 'write rkhunter config file' do
+    expect(chef_run).to create_template('/etc/rkhunter.conf').with(
+      :user => 'root',
+      :group => 0,
+      :mode => 00644
     )
   end
 end


### PR DESCRIPTION
 - [x] update `Gemfile` dependencies.
 - [x] add a `Rakefile`, with tasks `rake style`, `rake spec`, `rake integration`. The default `rake` runs all 3.
 - [x] set `.travis.yml` to run `rake ci`, currently an alias for `rake style`. Fixes #2 
 - [x] fixes our spec file to match the template change introduced in #3
 - [x] updates the license value in `metadata.rb`  to match README, LICENSE and the header listed in `recipes/default.rb`.